### PR TITLE
Add isRouteLeaving flag

### DIFF
--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -19,6 +19,8 @@ const projectDetail = ref({
   gallery: []
 })
 
+const isRouteLeaving = ref(false)
+
 let bsModalDOM = null
 let bsCarouselDOM = null
 
@@ -41,13 +43,15 @@ onMounted(() => {
   viewerEl = new Viewer(bsModalDOM)
 
   bsModalDOM.addEventListener('hide.bs.modal', function (e) {
-    if (this.viewer && this.viewer.isShown) {
+    if (this.viewer && this.viewer.isShown && !isRouteLeaving.value) {
       e.preventDefault()
     }
   })
 })
 
 onBeforeRouteLeave(() => {
+  isRouteLeaving.value = true
+
   if (bsModalEl) {
     bsModalEl.hide()
   }


### PR DESCRIPTION
It's because when route leaving, we should hide modal but, in the hide.bs.modal event it checks whether is viewer element shown or not, the problem is when route leaving, the viewer element is shown